### PR TITLE
Remove redirect.php logic

### DIFF
--- a/logic_ani24.py
+++ b/logic_ani24.py
@@ -77,11 +77,11 @@ class LogicAni24(object):
 
             #https://files0.filegroupa.com/files/0/new/id_39450.mp4
             #https://files0.filegroupa.com/redirect.php?path=%2ffiles%2f0%2fnew%2fid_39450.mp4
-            try:
-                if video_url.find('/redirect.php') != -1:
-                    video_url = video_url.split('/redirect.php')[0] + video_url.split('path=')[1].replace('%2f', '/')
-            except:
-                pass
+            #try:
+            #    if video_url.find('/redirect.php') != -1:
+            #        video_url = video_url.split('/redirect.php')[0] + video_url.split('path=')[1].replace('%2f', '/')
+            #except:
+            #    pass
             return video_url
         except Exception as e:
             logger.error('Exception:%s', e)


### PR DESCRIPTION
안녕하세요
ani24로 다운로드를 받아보려고 하니 대부분이 403 forbidden 에러가 발생하네요.
급한대로 redirect.php 없애는 부분을 주석으로 변경하였는데 동작은 합니다.

실제 redirect를 없애도 md5와 expires가 있어야 403 forbidden이 발생하지 않아 
redirect.php를 그대로 호출해서 다운로드 받을 수있게 주석으로 막아봤습니다.

--실제 Download 주소
https://new0.filegroupa.com/files/0/new/id_40110.mp4?md5=bm_r7RxC4YUFznQSNO38RQ&expires=1584119113